### PR TITLE
Add ability to npm link pages to this project for development purposes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,8 +9,12 @@ const nextConfig = {
 
 module.exports = nextConfig
 
+const transpileModulesOptions = process.env.NODE_ENV === 'local' ? {
+  resolveSymlinks: false // todo this is due to running `npm link` -> https://github.com/martpie/next-transpile-modules#note-on-resolvesymlinks
+} : {};
+
 // proceed to transpile typescript dependencies
 // https://github.com/martpie/next-transpile-modules#withtmtranspilemodules--options
-const withTM = require('next-transpile-modules')(['visual-regression-shared']); // pass the modules you would like to see transpiled
+const withTM = require('next-transpile-modules')(['visual-regression-shared'], transpileModulesOptions); // pass the modules you would like to see transpiled
 
 module.exports = withTM({});

--- a/server.js
+++ b/server.js
@@ -12,11 +12,6 @@ app.prepare().then(() => {
         // This tells it to parse the query portion of the URL.
         const parsedUrl = parse(req.url, true)
         const { pathname, query } = parsedUrl
-
-        if (!pathname.includes('/_next/static/')) {
-            console.log(pathname, query, parsedUrl)
-        }
-
         handle(req, res, parsedUrl)
     }).listen(3000, (err) => {
         if (err) throw err


### PR DESCRIPTION
When working with the "shared" project, it currently requires to pass in `resolveSymlinks: false` as an option otherwise errors will occur when webpack attempts to load it 